### PR TITLE
fix argument error when saving single images

### DIFF
--- a/imagenet_VCEs.py
+++ b/imagenet_VCEs.py
@@ -147,7 +147,7 @@ def _plot_counterfactuals(dir, original_imgs, orig_labels, segmentations, target
             ax[i+1].set_title(title)
 
 
-            save_image(perturbed_imgs[img_idx, target_idx, radius_idx].clip(0, 1), os.path.join(dir, 'single_images', f'{img_idx}.png'))
+            save_image(perturbed_imgs[img_idx+i, target_idx, radius_idx].clip(0, 1), os.path.join(dir, 'single_images', f'{img_idx}_{class_labels[img_target]}.png'))
 
         plt.tight_layout()
         if filenames is not None:


### PR DESCRIPTION
Make it correctly save two classes of CF results, as it originally can only save the first CF.